### PR TITLE
Persist#get(path)

### DIFF
--- a/src/Persist.js
+++ b/src/Persist.js
@@ -63,7 +63,7 @@ class Persist {
 			}
 			currentItem = currentItem[pathToken[i]];
 		}
-		if (!isTargetExist || !currentItem) {
+		if (!isTargetExist || currentItem === undefined) {
 			return null;
 		}
 		return currentItem;


### PR DESCRIPTION
for 루프 안에서 마지막으로 반환되는 currentItem의 경우 "", false, NaN 등의 명시적인 값이 올 수 있는데도 전부 null로 처리됨.