### PR TITLE
Hotfix/fix performace.navigation is existed

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,7 @@
 import {navigator, parseFloat, performance} from "./browser";
 
 const userAgent = navigator ? navigator.userAgent : "";
-const TYPE_BACK_FORWARD = (performance && performance.navigation.TYPE_BACK_FORWARD) || 2;
+const TYPE_BACK_FORWARD = (performance && performance.navigation && performance.navigation.TYPE_BACK_FORWARD) || 2;
 
 const isNeeded = (function() {
 	const isIOS = (new RegExp("iPhone|iPad", "i")).test(userAgent);
@@ -22,7 +22,7 @@ const isNeeded = (function() {
 
 // In case of IE8, TYPE_BACK_FORWARD is undefined.
 function isBackForwardNavigated() {
-	return performance && (performance.navigation.type === TYPE_BACK_FORWARD);
+	return (performance && performance.navigation && performance.navigation.type) === TYPE_BACK_FORWARD;
 }
 
 export {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,8 @@
 import {navigator, parseFloat, performance} from "./browser";
 
 const userAgent = navigator ? navigator.userAgent : "";
-const TYPE_BACK_FORWARD = (performance && performance.navigation && performance.navigation.TYPE_BACK_FORWARD) || 2;
+const TYPE_BACK_FORWARD = (performance && performance.navigation &&
+	performance.navigation.TYPE_BACK_FORWARD) || 2;
 
 const isNeeded = (function() {
 	const isIOS = (new RegExp("iPhone|iPad", "i")).test(userAgent);
@@ -22,7 +23,8 @@ const isNeeded = (function() {
 
 // In case of IE8, TYPE_BACK_FORWARD is undefined.
 function isBackForwardNavigated() {
-	return (performance && performance.navigation && performance.navigation.type) === TYPE_BACK_FORWARD;
+	return (performance && performance.navigation &&
+		performance.navigation.type) === TYPE_BACK_FORWARD;
 }
 
 export {


### PR DESCRIPTION
Recently, I tried to test egjs-persist by jest with jsdom
but can't find property`navigation.performance.TYPE_BACK_FORWARD` runtime exception during execution
JSDOM hasn't implemented yet, so need to check more carefully

