### PR TITLE
fix(utils): use pre-defined location object

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import {navigator, parseFloat, performance} from "./browser";
+import {navigator, parseFloat, performance, location} from "./browser";
 import {CONST_PERSIST} from "./consts";
 
 const userAgent = navigator ? navigator.userAgent : "";
@@ -26,7 +26,7 @@ function getNavigationType() {
 		performance.navigation.type;
 }
 function getUrl() {
-	return location.href.split("#")[0];
+	return location ? location.href.split("#")[0] : "";
 }
 function getStorageKey(name) {
 	return name + CONST_PERSIST;


### PR DESCRIPTION
As @daybrush intended to support Node.js environment in #29,
I think we should use pre-defined location object in `browser.js`

Currently, `location is not defined` error is emitted in the middle of the bundling process.