### PR TITLE
fix: fix missing clear method type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,11 @@ declare module "@egjs/persist" {
 
 	class Persist {
 		/**
+		 * Clear all information in Persist
+		 */
+		public static clear(): void;
+
+		/**
 		 * Return whether you need "Persist" module by checking the bfCache support of the current browser
 		 */
 		public static isNeeded(): boolean;


### PR DESCRIPTION
Hi. 

I found that [clear method](https://naver.github.io/egjs-persist/release/latest/doc/eg.Persist.html#.clear) is in documentation, but not in the type declaration file.

So i updated type declaration for `Persist`.

